### PR TITLE
Add warning and info color for all brands

### DIFF
--- a/src/tokens/brands/hot/color/application.dark.json
+++ b/src/tokens/brands/hot/color/application.dark.json
@@ -41,6 +41,14 @@
         "value": "{color.base.green.400}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.black}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.black}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.black}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.black}",
+          "comment": "The success color is used for success text."
         }
       }
     }

--- a/src/tokens/brands/hot/color/application.json
+++ b/src/tokens/brands/hot/color/application.json
@@ -41,6 +41,14 @@
         "value": "{color.base.green.500}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.white}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.white}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.white}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.white}",
+          "comment": "The success color is used for success text."
         }
       }
     }

--- a/src/tokens/brands/mb/color/application.dark.json
+++ b/src/tokens/brands/mb/color/application.dark.json
@@ -41,6 +41,14 @@
         "value": "{color.base.green.500}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.white}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.white}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.white}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.white}",
+          "comment": "The success color is used for success text."
         }
       }
     }

--- a/src/tokens/brands/mb/color/application.json
+++ b/src/tokens/brands/mb/color/application.json
@@ -41,6 +41,14 @@
         "value": "{color.base.green.500}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.white}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.white}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.white}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.white}",
+          "comment": "The success color is used for success text."
         }
       }
     }

--- a/src/tokens/brands/mbti/color/application.dark.json
+++ b/src/tokens/brands/mbti/color/application.dark.json
@@ -41,6 +41,14 @@
         "value": "{color.brand.green.400}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.black}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.black}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.black}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.black}",
+          "comment": "The success color is used for success text."
         }
       }
     }

--- a/src/tokens/brands/mbti/color/application.json
+++ b/src/tokens/brands/mbti/color/application.json
@@ -41,6 +41,14 @@
         "value": "{color.brand.green.800}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.black}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.white}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.white}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.white}",
+          "comment": "The success color is used for success text."
         }
       }
     }

--- a/src/tokens/brands/mbtm/color/application.dark.json
+++ b/src/tokens/brands/mbtm/color/application.dark.json
@@ -41,6 +41,14 @@
         "value": "{color.base.green.400}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.black}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.black}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.white}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.white}",
+          "comment": "The success color is used for success text."
         }
       }
     }

--- a/src/tokens/brands/mbtm/color/application.json
+++ b/src/tokens/brands/mbtm/color/application.json
@@ -41,6 +41,14 @@
         "value": "{color.base.green.500}",
         "comment": "The success color is used for success text."
       },
+      "info": {
+        "value": "{color.base.blue.500}",
+        "comment": "The error color is used for error text."
+      },
+      "warning": {
+        "value": "{color.base.yellow.500}",
+        "comment": "The success color is used for success text."
+      },
       "contrast": {
         "primary": {
           "value": "{color.base.white}",
@@ -81,6 +89,14 @@
         "success": {
           "value": "{color.base.white}",
           "comment": "The error contrast color is used for elements like text that is displayed on a background with the success color."
+        },
+        "info": {
+          "value": "{color.base.white}",
+          "comment": "The error color is used for error text."
+        },
+        "warning": {
+          "value": "{color.base.white}",
+          "comment": "The success color is used for success text."
         }
       }
     }


### PR DESCRIPTION
We add a `warning` and `info` color to all brands to follow MUI style.

## light mode
![Bildschirmfoto 2023-01-26 um 16 06 00](https://user-images.githubusercontent.com/118434520/214873063-9e88c617-aade-4aa8-8f65-2904c96b8eb2.png)

## dark mode
![Bildschirmfoto 2023-01-26 um 16 06 09](https://user-images.githubusercontent.com/118434520/214873162-6849eaf5-63b1-46a9-aab8-48cc7b668a12.png)

